### PR TITLE
Update Logger.php

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -83,9 +83,10 @@ class Logger
             'version' => $cloudWatchConfigs['version'],
         ];
 
-        if ($cloudWatchConfigs['credentials']['key']) {
-            $awsCredentials['credentials'] = $cloudWatchConfigs['credentials'];
+        if (!isset($cloudWatchConfigs['credentials'])) {
+            throw new IncompleteCloudWatchConfig('Missing credentials');
         }
+        $awsCredentials['credentials'] = $cloudWatchConfigs['credentials'];
 
         return $awsCredentials;
     }


### PR DESCRIPTION
AWS credentials can be a security token as well as key/secret strings. Adjusting to throw when credentials missing and removing test for ['key'] allowing config to supply app appropriate credentials.